### PR TITLE
Fix broken src path for rtc-ipmessaging

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
   <script src="/js/vendor/fingerprint2.js"></script>
   <script src="/js/vendor/superagent.js"></script>
   <script src="/js/tokenprovider.js"></script>
-  <script src="/js/twilio-rtc-ip-messaging.js"></script>
+  <script src="/js/twilio-rtc-ipmessaging.js"></script>
   <script src="/js/index.js"></script>
 </head>
 


### PR DESCRIPTION
new version of script file name take a dash.
the one in public/js folder does not.